### PR TITLE
Fix GitHub Actions to use short commit hash like Makefile

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -99,10 +99,11 @@ jobs:
           echo "  Git Branch: ${{ github.ref_name }}"
           
           # Build with build info (same as local Makefile)
+          GIT_COMMIT_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           docker build \
             --platform linux/amd64 \
             --build-arg BUILD_TIMESTAMP="$BUILD_TIMESTAMP" \
-            --build-arg GIT_COMMIT="${{ github.sha }}" \
+            --build-arg GIT_COMMIT="$GIT_COMMIT_SHORT" \
             --build-arg GIT_BRANCH="${{ github.ref_name }}" \
             --tag ${IMAGE_URL} \
             .


### PR DESCRIPTION
## Issue
GitHub Actions deployment was not matching local `make deploy` behavior.

## Root Cause
Found discrepancy in GIT_COMMIT build argument:
- **Makefile**: Uses `git rev-parse --short HEAD` → 7-character hash (e.g., `a87d8fd`)
- **GitHub Actions**: Uses `${{ github.sha }}` → 40-character hash (e.g., `a87d8fd1d4dbc3e0a133cdcc0d9e0ac1ad5cea64`)

## Fix
Modified GitHub Actions to use short commit hash to match Makefile exactly:
```bash
GIT_COMMIT_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
--build-arg GIT_COMMIT="$GIT_COMMIT_SHORT"
```

This ensures identical Docker builds between local and CI/CD deployment.