### PR TITLE
Fix timezone issue in nap detection

### DIFF
--- a/src/services/nap-calculator.js
+++ b/src/services/nap-calculator.js
@@ -12,7 +12,16 @@ class NapCalculator {
   static calculateNapStatus(sleepData) {
     // Find the main sleep session for last night
     // Look for 'long_sleep' type on today's date (Oura assigns sleep to the day it ends)
-    const today = new Date().toISOString().split("T")[0];
+    // IMPORTANT: Use Mountain Time for date, not UTC
+    const nowMT = new Date().toLocaleString("en-US", { 
+      timeZone: "America/Denver",
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    });
+    // Convert MM/DD/YYYY to YYYY-MM-DD format
+    const [month, day, year] = nowMT.split('/');
+    const today = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
 
     // Check if there's been a nap today (sleep that started between 11am-7pm MT)
     const todayNap = sleepData?.data?.find((record) => {
@@ -20,7 +29,13 @@ class NapCalculator {
 
       // Parse the bedtime_start to check if it's during daytime (11am-7pm MT)
       const bedtimeStart = new Date(record.bedtime_start);
-      const startHour = bedtimeStart.getHours();
+      
+      // Convert to Mountain Time to get the correct hour
+      const startHour = parseInt(bedtimeStart.toLocaleString("en-US", {
+        timeZone: "America/Denver",
+        hour: "2-digit",
+        hour12: false
+      }));
 
       // A nap is sleep that starts between 11am (11:00) and 7pm (19:00)
       const isDaytimeNap = startHour >= 11 && startHour < 19;


### PR DESCRIPTION
## Summary
- Fixed nap detection failing due to timezone mismatch
- App now correctly detects afternoon naps and shows "already napped" message
- All date/time comparisons now consistently use Mountain Time

## Problem
The nap detection was comparing dates using UTC time instead of Mountain Time. When it's late evening in MT (e.g., 9 PM), it's already the next day in UTC, causing the app to look for naps on the wrong date.

## Solution
1. Calculate "today" using Mountain Time instead of `new Date().toISOString()` (which uses UTC)
2. Convert `bedtime_start` to Mountain Time before checking if it falls within nap hours (11 AM - 7 PM)

## Test Results
Tested locally with actual Oura data showing a nap at 2:28 PM MT. The app now correctly:
- Detects the nap: `"hasNappedToday": true`
- Shows correct message: `"Not Nap Time"`
- Provides proper recommendation: `"emily has napped already. Another nap would be silly."`

🤖 Generated with [Claude Code](https://claude.ai/code)