### PR TITLE
Remove box styling around details panel

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -82,7 +82,6 @@
   max-width: 90vw;  /* Responsive on small screens */
   margin-left: auto;
   margin-right: auto;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);  /* Subtle shadow for depth */
 }
 
 .detail-row {
@@ -259,8 +258,6 @@
   
   .details-panel {
     background: #1a1a1a;
-    border: 1px solid #333;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
   }
   
   .detail-row {


### PR DESCRIPTION
## Summary
- Removed box-shadow from light mode details panel
- Removed border and box-shadow from dark mode details panel
- Results in cleaner appearance without box effect around the details section

## Changes
- Removed `box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1)` from `.details-panel` in light mode
- Removed `border: 1px solid #333` and `box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5)` from `.details-panel` in dark mode

The details panel now appears without any box styling as requested.