### PR TITLE
fix: handle 0.0 hours sleep with 'idk lol' message

### DIFF
--- a/src/services/nap-calculator.js
+++ b/src/services/nap-calculator.js
@@ -70,6 +70,38 @@ class NapCalculator {
     const sleepSeconds = sleepRecord?.total_sleep_duration || 0;
     const sleepHours = sleepSeconds / 3600;
 
+    // Check if we have no data (0.0 hours of sleep)
+    const hasNoData = sleepSeconds === 0 || !sleepRecord;
+    if (hasNoData) {
+      // Return special "idk lol" status when we have no data
+      return {
+        needsNap: false,
+        sleepHours: "0.0",
+        sleepScore: null,
+        sleepCategory: "no-data",
+        napPriority: "unknown",
+        quality: "Unknown",
+        isNapTime: this.isCurrentlyNapTime(),
+        isSleepTime: false,
+        currentTime: new Date().toLocaleString("en-US", {
+          timeZone: "America/Denver",
+          timeStyle: "short",
+        }),
+        lastUpdated: new Date().toISOString(),
+        message: "idk lol",
+        shouldNap: false,
+        recommendation: "The Oura API is responding, but no sleep data has been fetched yet. Emily's ring might still be syncing, or she might have forgotten to wear it. Check back in a few minutes!",
+        hasNappedToday: false,
+        details: {
+          totalSleepDurationSeconds: 0,
+          efficiency: null,
+          deepSleepMinutes: 0,
+          remSleepMinutes: 0,
+          lightSleepMinutes: 0,
+        },
+      };
+    }
+
     // Get readiness score (proxy for sleep quality in sleep sessions)
     const sleepScore = sleepRecord?.readiness?.score || null;
 
@@ -217,6 +249,7 @@ class NapCalculator {
    * @returns {string} Sleep category
    */
   static getSleepCategory(sleepHours) {
+    if (sleepHours === 0) return "no-data";
     if (sleepHours < 4) return "severely-deprived";
     if (sleepHours < 6) return "struggling";
     if (sleepHours <= 9) return "good";
@@ -232,6 +265,9 @@ class NapCalculator {
    */
   static getRecommendation(sleepHours, isNapTime, sleepCategory) {
     switch (sleepCategory) {
+      case "no-data":
+        return "The Oura API is responding, but no sleep data has been fetched yet. Emily's ring might still be syncing, or she might have forgotten to wear it. Check back in a few minutes!";
+        
       case "severely-deprived":
         return "Emily is severely sleep deprived. She should take a 20-30 minute nap immediately, regardless of the time.";
 

--- a/src/tests/nap-calculator-simple.test.js
+++ b/src/tests/nap-calculator-simple.test.js
@@ -13,7 +13,10 @@ describe('NapCalculator - Basic Tests', () => {
       expect(result.sleepHours).toBe('0.0');
       expect(result.sleepScore).toBe(null);
       expect(result.needsNap).toBe(false); // No sleep data means no nap needed
-      expect(result.message).toBeDefined();
+      expect(result.message).toBe('idk lol');
+      expect(result.sleepCategory).toBe('no-data');
+      expect(result.napPriority).toBe('unknown');
+      expect(result.recommendation).toContain('Oura API is responding');
       expect(result.currentTime).toBeDefined();
       expect(result.lastUpdated).toBeDefined();
       expect(result.details).toBeDefined();
@@ -25,18 +28,21 @@ describe('NapCalculator - Basic Tests', () => {
       expect(result.sleepHours).toBe('0.0');
       expect(result.sleepScore).toBe(null);
       expect(result.needsNap).toBe(false);
+      expect(result.message).toBe('idk lol');
+      expect(result.sleepCategory).toBe('no-data');
     });
 
     it('should calculate sleep hours correctly', () => {
       const mockSleepData = {
         data: [{
+          day: new Date().toISOString().split('T')[0],
+          type: 'long_sleep',
           total_sleep_duration: 21600, // 6 hours in seconds
-          score: 85,
-          contributors: {
-            deep_sleep: 90,
-            efficiency: 85,
-            restfulness: 80
-          }
+          readiness: { score: 85 },
+          efficiency: 85,
+          deep_sleep_duration: 5400, // 90 minutes in seconds
+          rem_sleep_duration: 7200, // 120 minutes in seconds
+          light_sleep_duration: 9000 // 150 minutes in seconds
         }]
       };
 
@@ -44,21 +50,23 @@ describe('NapCalculator - Basic Tests', () => {
       
       expect(result.sleepHours).toBe('6.0');
       expect(result.sleepScore).toBe(85);
-      expect(result.details.deepSleep).toBe(90);
+      expect(result.details.deepSleepMinutes).toBe(90);
       expect(result.details.efficiency).toBe(85);
-      expect(result.details.restfulness).toBe(80);
+      expect(result.details.remSleepMinutes).toBe(120);
+      expect(result.details.lightSleepMinutes).toBe(150);
     });
 
     it('should include all required fields in response', () => {
       const mockSleepData = {
         data: [{
+          day: new Date().toISOString().split('T')[0],
+          type: 'long_sleep',
           total_sleep_duration: 18000, // 5 hours
-          score: 75,
-          contributors: {
-            deep_sleep: 80,
-            efficiency: 90,
-            restfulness: 70
-          }
+          readiness: { score: 75 },
+          efficiency: 90,
+          deep_sleep_duration: 4800, // 80 minutes
+          rem_sleep_duration: 6000, // 100 minutes  
+          light_sleep_duration: 7200 // 120 minutes
         }]
       };
 
@@ -133,8 +141,10 @@ describe('NapCalculator - Basic Tests', () => {
     it('should provide detailed recommendations', () => {
       const mockSleepData = {
         data: [{
+          day: new Date().toISOString().split('T')[0],
+          type: 'long_sleep',
           total_sleep_duration: 18000, // 5 hours
-          score: 75
+          readiness: { score: 75 }
         }]
       };
 


### PR DESCRIPTION
## Summary
- Adds special handling for when Oura API returns no sleep data (0.0 hours)
- Displays "idk lol" as the main message instead of confusing "0.0 hours of sleep"
- Shows informative explanation that the API is working but data hasn't synced yet

## Problem
When the app loaded a few hours ago, it showed "0.0 hours of sleep" which was confusing. This happened because the Oura API was responding but hadn't received sleep data yet (ring might still be syncing or wasn't worn).

## Solution
Added detection in `nap-calculator.js` for when we have no sleep data:
- Returns `message: "idk lol"` 
- Sets `sleepCategory: "no-data"`
- Provides helpful recommendation text explaining the situation
- Suggests checking back in a few minutes for synced data

## Test Plan
- [x] Manual testing with empty data scenarios
- [x] Unit tests updated and passing
- [x] Frontend displays message correctly
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)