### PR TITLE
Fix YAML syntax errors in GitHub workflows

### DIFF
--- a/.github/workflows/cleanup-orphaned-previews.yml
+++ b/.github/workflows/cleanup-orphaned-previews.yml
@@ -97,30 +97,30 @@ jobs:
             
             # Calculate age in days using Python for portable date parsing
             AGE_DAYS=$(python3 -c "
-import datetime
-import sys
-
-# Parse ISO format timestamp
-created_str = '$CREATED'
-# Handle various ISO formats
-for fmt in ['%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S%z']:
-    try:
-        created = datetime.datetime.strptime(created_str, fmt)
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=datetime.timezone.utc)
-        break
-    except ValueError:
-        continue
-else:
-    # If none of the formats work, exit with error
-    print('ERROR: Could not parse date', file=sys.stderr)
-    sys.exit(1)
-
-# Calculate age in days
-now = datetime.datetime.now(datetime.timezone.utc)
-age_days = (now - created).days
-print(age_days)
-" 2>&1)
+            import datetime
+            import sys
+            
+            # Parse ISO format timestamp
+            created_str = '$CREATED'
+            # Handle various ISO formats
+            for fmt in ['%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S%z']:
+                try:
+                    created = datetime.datetime.strptime(created_str, fmt)
+                    if created.tzinfo is None:
+                        created = created.replace(tzinfo=datetime.timezone.utc)
+                    break
+                except ValueError:
+                    continue
+            else:
+                # If none of the formats work, exit with error
+                print('ERROR: Could not parse date', file=sys.stderr)
+                sys.exit(1)
+            
+            # Calculate age in days
+            now = datetime.datetime.now(datetime.timezone.utc)
+            age_days = (now - created).days
+            print(age_days)
+            " 2>&1)
             
             # Check if date parsing succeeded
             if [[ "$AGE_DAYS" == *"ERROR"* ]] || [[ ! "$AGE_DAYS" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -284,30 +284,30 @@ jobs:
               
               # Calculate age using Python for portable date parsing
               AGE_DAYS=$(python3 -c "
-import datetime
-import sys
-
-# Parse ISO format timestamp
-created_str = '$CREATED'
-# Handle various ISO formats
-for fmt in ['%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S%z']:
-    try:
-        created = datetime.datetime.strptime(created_str, fmt)
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=datetime.timezone.utc)
-        break
-    except ValueError:
-        continue
-else:
-    # If none of the formats work, exit with error
-    print('ERROR: Could not parse date', file=sys.stderr)
-    sys.exit(1)
-
-# Calculate age in days
-now = datetime.datetime.now(datetime.timezone.utc)
-age_days = (now - created).days
-print(age_days)
-" 2>&1)
+              import datetime
+              import sys
+              
+              # Parse ISO format timestamp
+              created_str = '$CREATED'
+              # Handle various ISO formats
+              for fmt in ['%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S%z']:
+                  try:
+                      created = datetime.datetime.strptime(created_str, fmt)
+                      if created.tzinfo is None:
+                          created = created.replace(tzinfo=datetime.timezone.utc)
+                      break
+                  except ValueError:
+                      continue
+              else:
+                  # If none of the formats work, exit with error
+                  print('ERROR: Could not parse date', file=sys.stderr)
+                  sys.exit(1)
+              
+              # Calculate age in days
+              now = datetime.datetime.now(datetime.timezone.utc)
+              age_days = (now - created).days
+              print(age_days)
+              " 2>&1)
               
               # Check if date parsing succeeded
               if [[ "$AGE_DAYS" == *"ERROR"* ]] || [[ ! "$AGE_DAYS" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- Fixed YAML syntax errors on line 100 of cleanup-orphaned-previews.yml
- Fixed YAML syntax errors on line 287 of deploy-main.yml
- Added proper indentation for Python multiline strings within YAML

## Problem
The Python code blocks in the YAML files weren't properly indented, causing GitHub Actions to fail with syntax errors.

## Solution
Ensured all lines within the Python multiline strings have consistent indentation that works with YAML's parsing requirements.

## Testing
- Linting passes
- Type checks pass
- YAML files now parse correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>