### PR TITLE
Fix cleanup workflow arithmetic operation exit codes

### DIFF
--- a/.github/workflows/cleanup-orphaned-previews.yml
+++ b/.github/workflows/cleanup-orphaned-previews.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'
+  # Temporary trigger for testing
+  pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
     inputs:
       days_old:
@@ -91,7 +94,7 @@ jobs:
             
             if [ -z "$CREATED" ]; then
               echo "Warning: Could not get creation time for $SERVICE, skipping"
-              ((SKIP_COUNT++))
+              ((SKIP_COUNT++)) || true
               continue
             fi
             
@@ -101,7 +104,7 @@ jobs:
             # Check if date parsing succeeded
             if [[ "$AGE_DAYS" == *"ERROR"* ]] || [[ ! "$AGE_DAYS" =~ ^[0-9]+$ ]]; then
               echo "Warning: Could not parse date for $SERVICE (date: $CREATED), skipping"
-              ((SKIP_COUNT++))
+              ((SKIP_COUNT++)) || true
               continue
             fi
             
@@ -111,14 +114,14 @@ jobs:
             if [ $AGE_DAYS -gt $DAYS_OLD ]; then
               if [ "$DRY_RUN" = "true" ]; then
                 echo "  [DRY RUN] Would delete $SERVICE"
-                ((CLEANUP_COUNT++))
+                ((CLEANUP_COUNT++)) || true
               else
                 # Check if PR is still open by querying GitHub API
                 PR_STATE=$(gh pr view $PR_NUMBER --json state --jq .state 2>/dev/null || echo "unknown")
                 
                 if [ "$PR_STATE" = "OPEN" ]; then
                   echo "  Skipping $SERVICE - PR #$PR_NUMBER is still open"
-                  ((SKIP_COUNT++))
+                  ((SKIP_COUNT++)) || true
                   continue
                 fi
                 
@@ -131,7 +134,7 @@ jobs:
                   --project ${{ env.PROJECT_ID }} \
                   --quiet; then
                   echo "  Deleted $SERVICE"
-                  ((CLEANUP_COUNT++))
+                  ((CLEANUP_COUNT++)) || true
                   
                   # Also clean up container images
                   IMAGE_PREFIX="${{ env.ARTIFACT_REGISTRY_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPO }}/${SERVICE}"
@@ -151,12 +154,12 @@ jobs:
                   fi
                 else
                   echo "  Failed to delete $SERVICE"
-                  ((SKIP_COUNT++))
+                  ((SKIP_COUNT++)) || true
                 fi
               fi
             else
               echo "  Keeping $SERVICE - only $AGE_DAYS days old"
-              ((SKIP_COUNT++))
+              ((SKIP_COUNT++)) || true || true
             fi
           done
           

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ help: ## Show available commands
 	@echo "  $(GREEN)make lint$(NC)         - Run linters for both frontend and backend"
 	@echo "  $(GREEN)make format$(NC)       - Format code (frontend and backend)"
 	@echo "  $(GREEN)make test$(NC)         - Run all tests"
+	@echo "  $(GREEN)make validate-workflows$(NC) - Validate GitHub Actions workflow syntax"
 	@echo ""
 	@echo "$(GREEN)Security:$(NC)"
 	@echo "  $(GREEN)make scan-secrets$(NC) - Scan repository for secrets with TruffleHog"
@@ -289,6 +290,16 @@ lint: ## Run linters
 		echo "$(YELLOW)flake8 not installed, skipping Python linting$(NC)"; \
 	fi
 	@echo "$(GREEN) Linting complete$(NC)"
+
+.PHONY: validate-workflows
+validate-workflows: ## Validate GitHub Actions workflow syntax
+	@echo "$(GREEN)Validating GitHub Actions workflows...$(NC)"
+	@if [ -f scripts/validate-workflows.sh ]; then \
+		./scripts/validate-workflows.sh; \
+	else \
+		echo "$(RED)Error: scripts/validate-workflows.sh not found$(NC)"; \
+		exit 1; \
+	fi
 
 .PHONY: deploy
 deploy: build ## Deploy to Google Cloud Run

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Validate GitHub Actions workflow files before merging
+
+set -e
+
+echo "GitHub Actions Workflow Validator"
+echo "================================="
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Track validation results
+ERRORS=0
+WARNINGS=0
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check for required tools
+echo "Checking for required tools..."
+
+# Check for yamllint
+if command_exists yamllint; then
+    echo -e "${GREEN}✓${NC} yamllint found"
+else
+    echo -e "${YELLOW}!${NC} yamllint not found. Install with: pip install yamllint"
+    echo "  Skipping YAML syntax validation..."
+fi
+
+# Check for actionlint
+if command_exists actionlint; then
+    echo -e "${GREEN}✓${NC} actionlint found"
+else
+    echo -e "${YELLOW}!${NC} actionlint not found. Install from: https://github.com/rhysd/actionlint"
+    echo "  Skipping GitHub Actions specific validation..."
+fi
+
+echo ""
+
+# Find all workflow files
+WORKFLOW_FILES=$(find .github/workflows -name '*.yml' -o -name '*.yaml' 2>/dev/null || true)
+
+if [ -z "$WORKFLOW_FILES" ]; then
+    echo "No workflow files found in .github/workflows/"
+    exit 0
+fi
+
+echo "Found workflow files:"
+echo "$WORKFLOW_FILES" | while read -r file; do
+    echo "  - $file"
+done
+echo ""
+
+# Validate each workflow file
+for file in $WORKFLOW_FILES; do
+    echo "Validating: $file"
+    echo "-------------------"
+    
+    # Basic file existence check
+    if [ ! -f "$file" ]; then
+        echo -e "${RED}✗${NC} File not found: $file"
+        ((ERRORS++))
+        continue
+    fi
+    
+    # YAML syntax validation with yamllint
+    if command_exists yamllint; then
+        echo -n "  YAML Syntax: "
+        if yamllint -d relaxed "$file" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓${NC} Valid"
+        else
+            echo -e "${RED}✗${NC} Invalid"
+            echo "  Errors:"
+            yamllint -d relaxed "$file" 2>&1 | sed 's/^/    /'
+            ((ERRORS++))
+        fi
+    fi
+    
+    # GitHub Actions specific validation with actionlint
+    if command_exists actionlint; then
+        echo -n "  GitHub Actions: "
+        if actionlint "$file" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓${NC} Valid"
+        else
+            echo -e "${RED}✗${NC} Issues found"
+            echo "  Issues:"
+            actionlint "$file" 2>&1 | sed 's/^/    /'
+            ((WARNINGS++))
+        fi
+    fi
+    
+    # Check for common issues
+    echo "  Common issues check:"
+    
+    # Check for multi-line Python code that might cause YAML issues
+    if grep -q 'python3 -c "' "$file"; then
+        MULTILINE_PYTHON=$(grep -n -A5 'python3 -c "' "$file" | grep -E '^[0-9]+-' | wc -l)
+        if [ "$MULTILINE_PYTHON" -gt 1 ]; then
+            echo -e "    ${YELLOW}!${NC} Multi-line Python code detected (prone to YAML errors)"
+            echo "      Consider using single-line format or external scripts"
+            ((WARNINGS++))
+        else
+            echo -e "    ${GREEN}✓${NC} Python code is single-line"
+        fi
+    fi
+    
+    # Check for proper indentation in run blocks
+    if grep -E '^\s*run:' "$file" > /dev/null; then
+        # Check if the line after 'run:' has proper indentation
+        if grep -A1 -E '^\s*run:' "$file" | grep -E '^[^\s]' > /dev/null; then
+            echo -e "    ${RED}✗${NC} Improper indentation after 'run:' blocks"
+            ((ERRORS++))
+        else
+            echo -e "    ${GREEN}✓${NC} Proper indentation in run blocks"
+        fi
+    fi
+    
+    echo ""
+done
+
+# Summary
+echo "Validation Summary"
+echo "=================="
+if [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
+    echo -e "${GREEN}✓ All workflows are valid!${NC}"
+    exit 0
+else
+    if [ $ERRORS -gt 0 ]; then
+        echo -e "${RED}✗ Found $ERRORS error(s)${NC}"
+    fi
+    if [ $WARNINGS -gt 0 ]; then
+        echo -e "${YELLOW}! Found $WARNINGS warning(s)${NC}"
+    fi
+    
+    echo ""
+    echo "Recommendations:"
+    echo "1. Fix all errors before merging"
+    echo "2. Consider addressing warnings to improve workflow reliability"
+    echo "3. Test workflows in a branch before merging to main"
+    echo "4. Use 'act' tool to test workflows locally: https://github.com/nektos/act"
+    
+    # Exit with error if there were errors
+    if [ $ERRORS -gt 0 ]; then
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions cleanup workflow that was failing when no environments were cleaned up.

## Problem
The cleanup workflow was failing with exit code 1 when it only found preview environments that weren't old enough to clean up. This happened because:
- Bash arithmetic operations like `((SKIP_COUNT++))` return exit code 1 when the result is 0
- With `set -e` enabled (exit on error), this causes the script to exit unexpectedly
- This occurred on the last increment operation when only one service was found and skipped

## Solution
Add `|| true` after all arithmetic increment operations to ensure they don't cause the script to exit unexpectedly.

## Changes
- ✅ Fix all `((SKIP_COUNT++))` and `((CLEANUP_COUNT++))` operations to handle zero results
- ✅ Add temporary PR trigger for testing the workflow before merging
- ✅ Add workflow validation tools:
  - `scripts/validate-workflows.sh` for syntax checking
  - `make validate-workflows` command for easy validation

## Testing
The workflow will now run on this PR due to the temporary trigger. We can verify it completes successfully even when no environments are cleaned up.

## Next Steps
After merging, remember to remove the temporary PR trigger in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.ai/code)